### PR TITLE
Make ASI on game root directory run by default on example global.ini file

### DIFF
--- a/data/scripts/global.ini
+++ b/data/scripts/global.ini
@@ -1,6 +1,6 @@
 [GlobalSets]
 LoadPlugins=1
-LoadFromScriptsOnly=1
+LoadFromScriptsOnly=0
 DontLoadFromDllMain=1
 FindModule=0
 UseD3D8to9=0


### PR DESCRIPTION
The example global.ini file prevents loading any ASI in the game root directory, as some mods like CLEO and modloader requires to be loaded on the root directory in order for those mods to work.

Changing LoadFromScriptsOnly from 1 to 0 so that ASI in the game root directory is loaded.