### PR TITLE
Fix for a vanishing .bind section (observed in Yakuza 4)

### DIFF
--- a/source/dllmain.cpp
+++ b/source/dllmain.cpp
@@ -889,6 +889,10 @@ bool HookKernel32IAT(HMODULE mod, bool exe)
     static auto getSectionEnd = [](IMAGE_NT_HEADERS* ntHeader, size_t inst) -> auto
     {
         auto sec = getSection(ntHeader, ntHeader->FileHeader.NumberOfSections - 1);
+        // .bind section may have vanished from the executable (test case: Yakuza 4)
+        // so back to the first valid section if that happened
+        while (sec->Misc.VirtualSize == 0) sec--;
+
         auto secSize = max(sec->SizeOfRawData, sec->Misc.VirtualSize);
         auto end = inst + max(sec->PointerToRawData, sec->VirtualAddress) + secSize;
         return end;


### PR DESCRIPTION
in Yakuza 4 Steam executable, `.bind` section vanishes from memory by the time UAL injects (without changing `NumberOfSections`). As a failsafe, detect this and walk back through sections until encountering a valid section.