### PR TITLE
Simplify CI Steps

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,56 +1,113 @@
 name: GitHub Actions Build
 
 on:
-  pull_request:
   push:
+    paths-ignore:
+      - "**/*.md"
+      - '**/*.txt'
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - '**/*.txt'
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
 
 jobs:
   build:
-    runs-on: windows-2022
-    strategy:
-      matrix:
-        platform: [Win32, x64]
-        buildtype: [Release]
+    runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v3
       with:
-        submodules: 'true'
-    - name: DX SDK
-      shell: bash
+        submodules: recursive
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@main
+
+    - name: Setup DirectX SDK
       run:  |
-        curl -L https://download.microsoft.com/download/a/e/7/ae743f1f-632b-4809-87a9-aa1bb3458e31/DXSDK_Jun10.exe -o DX.exe
-        7z x DX.exe DXSDK/Include -oDX
-        7z x DX.exe DXSDK/Lib/x86 -oDX
+        curl -fLOS https://download.microsoft.com/download/a/e/7/ae743f1f-632b-4809-87a9-aa1bb3458e31/DXSDK_Jun10.exe
+        7z x DXSDK_Jun10.exe DXSDK/Include -oDX
+        7z x DXSDK_Jun10.exe DXSDK/Lib/x86 -oDX
         mv DX/DXSDK "C:/Program Files (x86)/Microsoft DirectX SDK (June 2010)"
+
     - name: Configure build
-      shell: cmd
-      run: |
-        ./premake5.bat
+      run: ./premake5.bat
+
     - name: Build
-      shell: cmd
       run: |
-        msbuild -m build/Ultimate-ASI-Loader-${{matrix.platform}}.sln /property:Configuration=${{matrix.buildtype}} /property:Platform=${{matrix.platform}}
+        msbuild -m build/Ultimate-ASI-Loader-x64.sln /property:Configuration=Release /property:Platform=x64
+        msbuild -m build/Ultimate-ASI-Loader-Win32.sln /property:Configuration=Release /property:Platform=Win32
+
     - name: Pack binaries
-      shell: cmd
-      run: |
-        release-${{matrix.platform}}.bat
-    - name: Get release info
-      id: release_info
-      uses: cardinalby/git-get-release-action@1.1.1
+      run: ./release.ps1
+
+    - name: Upload artifact (Win32)
+      uses: actions/upload-artifact@v3
+      with:
+        name: Ultimate-ASI-Loader-Win32
+        path: dist/Win32/dll/*
+
+    - name: Upload artifact (x64)
+      uses: actions/upload-artifact@v3
+      with:
+        name: Ultimate-ASI-Loader-x64
+        path: dist/x64/dll/*
+
+    - name: Get release info (Win32)
+      if: |
+        github.ref_name == 'main' &&
+        github.event_name == 'push' &&
+        github.repository == 'ThirteenAG/Ultimate-ASI-Loader'
+      id: release_info_x86
+      uses: cardinalby/git-get-release-action@master
       env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag: ${{matrix.platform}}-latest
-    - name: Upload Release
-      uses: ncipollo/release-action@v1
+        tag: Win32-latest
+
+    - name: Upload Release (Win32)
+      if: |
+        github.ref_name == 'main' &&
+        github.event_name == 'push' &&
+        github.repository == 'ThirteenAG/Ultimate-ASI-Loader'
+      uses: ncipollo/release-action@main
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         allowUpdates: true
-        name: ${{ steps.release_info.outputs.name }}
-        body: ${{ steps.release_info.outputs.body }}
-        tag: ${{ steps.release_info.outputs.tag_name }}
-        artifacts: bin/*.zip
+        name: ${{ steps.release_info_x86.outputs.name }}
+        body: ${{ steps.release_info_x86.outputs.body }}
+        tag: ${{ steps.release_info_x86.outputs.tag_name }}
+        artifacts: dist/Win32/zip/*.zip
+
+    - name: Get release info (Win64)
+      if: |
+        github.ref_name == 'main' &&
+        github.event_name == 'push' &&
+        github.repository == 'ThirteenAG/Ultimate-ASI-Loader'
+      id: release_info_x64
+      uses: cardinalby/git-get-release-action@master
+      env:
+       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag: x64-latest
+
+    - name: Upload Release (Win64)
+      if: |
+        github.ref_name == 'main' &&
+        github.event_name == 'push' &&
+        github.repository == 'ThirteenAG/Ultimate-ASI-Loader'
+      uses: ncipollo/release-action@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        allowUpdates: true
+        name: ${{ steps.release_info_x64.outputs.name }}
+        body: ${{ steps.release_info_x64.outputs.body }}
+        tag: ${{ steps.release_info_x64.outputs.tag_name }}
+        artifacts: dist/x64/zip/*.zip

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,4 @@
-![AppVeyor](https://img.shields.io/appveyor/build/ThirteenAG/Ultimate-ASI-Loader?label=AppVeyor%20Build&logo=AppVeyor&logoColor=white)
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/ThirteenAG/Ultimate-ASI-Loader/msbuild.yml?branch=master&label=GitHub%20Actions%20Build&logo=GitHub)](https://github.com/ThirteenAG/Ultimate-ASI-Loader/actions/workflows/msbuild.yml)
+[![GitHub Actions Build](https://github.com/ThirteenAG/Ultimate-ASI-Loader/actions/workflows/msbuild.yml/badge.svg)](https://github.com/ThirteenAG/Ultimate-ASI-Loader/actions/workflows/msbuild.yml)
 
 # Ultimate ASI Loader
 
@@ -22,7 +21,6 @@ This is a DLL file which adds ASI plugin loading functionality to any game, whic
 - wininet.dll ([x86](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/Win32-latest/wininet.zip) and [x64](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/x64-latest/wininet.zip))
 - winmm.dll ([x86](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/Win32-latest/winmm.zip) and [x64](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/x64-latest/winmm.zip))
 - [xlive.dll](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/Win32-latest/xlive.zip)
-
 - [bink2w64.dll](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/x64-latest/bink2w64.zip) (rename original to bink2w64Hooked.dll)
 - [vorbisFile.dll](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/Win32-latest/vorbisFile.zip) (rename original to vorbisHooked.dll, optional)
 - [binkw32.dll](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/Win32-latest/binkw32.zip) (rename original to binkw32Hooked.dll, optional)
@@ -48,7 +46,7 @@ ASI loader have built-in wndmode.dll, which can be loaded, if you create empty w
 
 Some mods, like [SkyGfx](https://github.com/aap/skygfx_vc) require [d3d8to9](https://github.com/crosire/d3d8to9). It is also a part of ASI loader, so in order to use it, create global.ini inside scripts folder with the following content:
 
-```
+```ini
 [GlobalSets]
 UseD3D8to9=1
 ```
@@ -81,7 +79,7 @@ ASI loader is now capable of generating crash minidumps and crash logs. To use t
 13. Place Ultimate ASI Loader DLL into game directory. You need to find out which name works for a specific game, in case of GTA SA I've used **d3d11.dll**, so I put **dinput8.dll** from x86 archive and renamed it to **d3d11.dll**.
 14. Create an ini file with the same name, in this case: **d3d11.ini**, with the following content:
 
-```
+```ini
 [GlobalSets]
 DontLoadFromDllMain=0
 ```

--- a/release-Win32.bat
+++ b/release-Win32.bat
@@ -1,9 +1,10 @@
 set list=d3d8, d3d9, d3d10, d3d11, d3d12, ddraw, dinput, dinput8, dsound, msacm32, msvfw32, version, wininet, winmm, xlive, vorbisFile, binkw32
-cd ./bin/Win32/Release/
+mkdir dist\Win32
+cd .\bin\Win32\Release
 (for %%a in (%list%) do (
    copy dinput8.dll %%a.dll
 ))
 cd ../../../
 (for %%a in (%list%) do (
-   7za a -tzip ".\bin\%%a.zip" ".\bin\Win32\Release\%%a.dll"
+   7za a -tzip ".\bin\%%a-Win32.zip" ".\bin\Win32\Release\%%a.dll"
 ))

--- a/release-x64.bat
+++ b/release-x64.bat
@@ -1,9 +1,10 @@
 set list=d3d9, d3d10, d3d11, d3d12, dinput8, dsound, version, wininet, winmm, bink2w64
-cd ./bin/x64/Release/
+mkdir dist\x64
+cd bin\x64\Release\
 (for %%a in (%list%) do (
    copy dinput8.dll %%a.dll
 ))
 cd ../../../
 (for %%a in (%list%) do (
-   7za a -tzip ".\bin\%%a.zip" ".\bin\x64\Release\%%a.dll"
+   7za a -tzip ".\bin\%%a-x64.zip" ".\bin\x64\Release\%%a.dll"
 ))

--- a/release.ps1
+++ b/release.ps1
@@ -1,0 +1,48 @@
+$aliases_array_Win32 = "d3d8", "d3d9", "d3d10", "d3d11", "d3d12", "dinput8", "ddraw", "dinput", "dsound", "msacm32", "msvfw32", "version", "wininet", "winmm", "xlive", "vorbisFile", "binkw32"
+$aliases_array_x64   = "d3d9", "d3d10", "d3d11", "d3d12", "dinput8", "dsound", "version", "wininet", "winmm", "bink2w64"
+$platform_array      = "Win32", "x64"
+$hash_alrg           = "SHA512"
+
+foreach ($platform in $platform_array)
+{
+    mkdir "dist\$platform\dll"
+    mkdir "dist\$platform\zip"
+    if ($platform -eq "Win32") {
+        Move-Item ".\bin\$platform\Release\dinput8.dll" ".\bin\$platform\Release\_dinput8.dll"
+        foreach ($file in $aliases_array_Win32) {
+            Copy-Item ".\bin\$platform\Release\_dinput8.dll" ".\bin\$platform\Release\$file.dll"
+        }
+    }
+    else
+    {
+        Move-Item ".\bin\$platform\Release\dinput8.dll" ".\bin\$platform\Release\_dinput8.dll"
+        foreach ($file in $aliases_array_x64) {
+            Copy-Item ".\bin\$platform\Release\_dinput8.dll" ".\bin\$platform\Release\$file.dll"
+        }
+    }
+    if ($platform -eq "Win32") {
+        foreach ($file in $aliases_array_Win32) {
+            Get-FileHash ".\bin\$platform\Release\$file.dll" -Algorithm "$hash_alrg" | Format-List | Out-File -Encoding "utf8" ".\bin\$file-$platform.$hash_alrg"
+            Copy-Item ".\bin\$platform\Release\$file.dll", ".\bin\$file-$platform.$hash_alrg" -Destination ".\dist\$platform\dll\"
+            $compress = @{
+                Path             = ".\bin\$platform\Release\$file.dll", ".\bin\$file-$platform.$hash_alrg"
+                CompressionLevel = "NoCompression"
+                DestinationPath  = ".\dist\$platform\zip\$file-$platform.zip"
+            }
+            Compress-Archive @compress
+        }
+    }
+    else
+    {
+        foreach ($file in $aliases_array_x64) {
+            Get-FileHash ".\bin\$platform\Release\$file.dll" -Algorithm "$hash_alrg" | Format-List | Out-File -Encoding "utf8" ".\bin\$file-$platform.$hash_alrg"
+            Copy-Item ".\bin\$platform\Release\$file.dll", ".\bin\$file-$platform.$hash_alrg" -Destination ".\dist\$platform\dll\"
+            $compress = @{
+                Path             = ".\bin\$platform\Release\$file.dll", ".\bin\$file-$platform.$hash_alrg"
+                CompressionLevel = "NoCompression"
+                DestinationPath  = ".\dist\$platform\zip\$file-$platform.zip"
+            }
+            Compress-Archive @compress
+        }
+    }
+}


### PR DESCRIPTION
- Remove matrixes (Windows Instances are already slow to start)
- Make release filenames `names-platform.zip`
- Generate file hash for dlls
