### PR TITLE
Load ASI recursive in scripts

### DIFF
--- a/data/scripts/global.ini
+++ b/data/scripts/global.ini
@@ -1,7 +1,7 @@
 [GlobalSets]
 LoadPlugins=1
 LoadFromScriptsOnly=1
-LoadFromScriptsRecursive=0
+LoadRecursively=1
 DontLoadFromDllMain=1
 ;LoadFromAPI=GetSystemTimeAsFileTime
 FindModule=0

--- a/data/scripts/global.ini
+++ b/data/scripts/global.ini
@@ -1,6 +1,7 @@
 [GlobalSets]
 LoadPlugins=1
 LoadFromScriptsOnly=1
+LoadFromScriptsRecursive=0
 DontLoadFromDllMain=1
 ;LoadFromAPI=GetSystemTimeAsFileTime
 FindModule=0

--- a/source/dllmain.cpp
+++ b/source/dllmain.cpp
@@ -691,6 +691,39 @@ void FindFiles(WIN32_FIND_DATAW* fd)
     }
 }
 
+void FindPlugins(WIN32_FIND_DATAW fd,
+                 const wchar_t* szPath,
+                 const wchar_t* szSelfPath,
+                 const UINT nWantsToLoadFromScriptsRecursive)
+{
+    if (!std::filesystem::exists(szPath))
+        return;
+
+    // Try to find ASI in directories inside szPath
+    if (nWantsToLoadFromScriptsRecursive)
+    {
+        for (auto& i : std::filesystem::directory_iterator(szPath))
+        {
+            if (!i.is_directory())
+                continue;
+
+            SetCurrentDirectoryW(szSelfPath);
+
+            if (SetCurrentDirectoryW(i.path().wstring().c_str()))
+                FindFiles(&fd);
+        }
+    }
+
+    // Try to find ASI only inside szPath, not in directories
+    SetCurrentDirectoryW(szSelfPath);
+
+    if (SetCurrentDirectoryW(szPath))
+        FindFiles(&fd);
+
+    // After all, need to restore current directory to self path
+    SetCurrentDirectoryW(szSelfPath);
+}
+
 void LoadPlugins()
 {
     auto oldDir = GetCurrentDirectoryW(); // store the current directory
@@ -755,6 +788,7 @@ void LoadPlugins()
 
     auto nWantsToLoadPlugins = GetPrivateProfileIntW(L"globalsets", L"loadplugins", TRUE, iniPaths);
     auto nWantsToLoadFromScriptsOnly = GetPrivateProfileIntW(L"globalsets", L"loadfromscriptsonly", FALSE, iniPaths);
+    auto nWantsToLoadFromScriptsRecursive = GetPrivateProfileIntW(L"globalsets", L"loadfromscriptsrecursive", FALSE, iniPaths);
 
     if (nWantsToLoadPlugins)
     {
@@ -762,22 +796,18 @@ void LoadPlugins()
         if (!nWantsToLoadFromScriptsOnly)
             FindFiles(&fd);
 
-        SetCurrentDirectoryW(szSelfPath.c_str());
+        FindPlugins(
+          fd, L"scripts", szSelfPath.c_str(), nWantsToLoadFromScriptsRecursive);
 
-        if (SetCurrentDirectoryW(L"scripts\\"))
-            FindFiles(&fd);
-
-        SetCurrentDirectoryW(szSelfPath.c_str());
-
-        if (SetCurrentDirectoryW(L"plugins\\"))
-            FindFiles(&fd);
-
-        SetCurrentDirectoryW(szSelfPath.c_str());
+        FindPlugins(
+          fd, L"plugins", szSelfPath.c_str(), nWantsToLoadFromScriptsRecursive);
 
         if (!sFileLoaderPath.empty())
         {
-            if (SetCurrentDirectoryW(sFileLoaderPath.wstring().c_str()))
-                FindFiles(&fd);
+            FindPlugins(fd,
+                        sFileLoaderPath.c_str(),
+                        szSelfPath.c_str(),
+                        nWantsToLoadFromScriptsRecursive);
         }
     }
 

--- a/source/dllmain.cpp
+++ b/source/dllmain.cpp
@@ -694,17 +694,22 @@ void FindFiles(WIN32_FIND_DATAW* fd)
 void FindPlugins(WIN32_FIND_DATAW fd,
                  const wchar_t* szPath,
                  const wchar_t* szSelfPath,
-                 const UINT nWantsToLoadFromScriptsRecursive)
+                 const UINT nWantsToLoadRecursively)
 {
     if (!std::filesystem::exists(szPath))
         return;
 
     // Try to find ASI in directories inside szPath
-    if (nWantsToLoadFromScriptsRecursive)
+    if (nWantsToLoadRecursively)
     {
-        for (auto& i : std::filesystem::directory_iterator(szPath))
+        std::error_code ec;
+        constexpr auto perms =
+          std::filesystem::directory_options::skip_permission_denied |
+          std::filesystem::directory_options::follow_directory_symlink;
+
+        for (auto& i : std::filesystem::directory_iterator(szPath, perms, ec))
         {
-            if (!i.is_directory())
+            if (!i.is_directory(ec))
                 continue;
 
             SetCurrentDirectoryW(szSelfPath);
@@ -788,26 +793,29 @@ void LoadPlugins()
 
     auto nWantsToLoadPlugins = GetPrivateProfileIntW(L"globalsets", L"loadplugins", TRUE, iniPaths);
     auto nWantsToLoadFromScriptsOnly = GetPrivateProfileIntW(L"globalsets", L"loadfromscriptsonly", FALSE, iniPaths);
-    auto nWantsToLoadFromScriptsRecursive = GetPrivateProfileIntW(L"globalsets", L"loadfromscriptsrecursive", FALSE, iniPaths);
+    auto nWantsToLoadRecursively = GetPrivateProfileIntW(L"globalsets", L"loadrecursively", TRUE, iniPaths);
 
     if (nWantsToLoadPlugins)
     {
         WIN32_FIND_DATAW fd;
         if (!nWantsToLoadFromScriptsOnly)
+        {
+            SetCurrentDirectoryW(szSelfPath.c_str());
             FindFiles(&fd);
+        }
 
         FindPlugins(
-          fd, L"scripts", szSelfPath.c_str(), nWantsToLoadFromScriptsRecursive);
+          fd, L"scripts", szSelfPath.c_str(), nWantsToLoadRecursively);
 
         FindPlugins(
-          fd, L"plugins", szSelfPath.c_str(), nWantsToLoadFromScriptsRecursive);
+          fd, L"plugins", szSelfPath.c_str(), nWantsToLoadRecursively);
 
         if (!sFileLoaderPath.empty())
         {
             FindPlugins(fd,
                         sFileLoaderPath.c_str(),
                         szSelfPath.c_str(),
-                        nWantsToLoadFromScriptsRecursive);
+                        nWantsToLoadRecursively);
         }
     }
 


### PR DESCRIPTION
My PR introduces the ability to load ASI plugins recursively from the `scripts`/`plugins`/`update` directories and adds the option to enable this feature in the `global.ini` file (it is disabled by default). This allows for better organization of the plugin folder, but only when the `LoadFromScriptsRecursive` variable is set to `1`.

## Simple presentation:
I want to load several plugins that belong to a modification called `MySuperMod`, so I create a `MySuperMod` folder in `scripts`/`plugins`/`update` and then place several ASI plugins there. This way, I know that in case of inconsistent plugin names, we can easily find them.

It doesn't matter whether `LoadFromScriptsRecursive` is set to `0` or `1`, the plugins located in scripts/plugins will still be loaded, which is obvious.